### PR TITLE
Adds permissions to produced plugin.yml

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -39,6 +39,13 @@ bukkit {
     author = 'GufliMC'
     website = 'https://github.com/GufliMC/TreasureChests'
     apiVersion = '1.16'
+    
+    permissions {
+        'treasurechests.setup' {
+            description = 'Allows setting up a new treasure chest'
+            setDefault('OP')
+        }
+    }
 }
 
 // I want it nice like that


### PR DESCRIPTION
This change adds the `treasurechests.setup` permission to the list of permissions in plugin.yml. This change makes it possible for permission managers such as LuckPerms to auto-complete permissions for TreasureChests.